### PR TITLE
feat: add additional metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ The metrics will be registered under the name `horizon_current_processes.<queue_
 The default schedule for this is every 10 minutes (`*/10 * * * *`), to configure this,
 add `MeterName::CurrentProcesses->value` under a `horizon` key in your `telemetry.php` config file.
 
-#### [`CurrentWorkloadMetric`](src/Metrics/CurrentWorkloadMetric.php)
+#### [`CurrentJobsMetric`](src/Metrics/CurrentJobsMetric.php)
 
-The `CurrentWorkloadMetric` will register the current number of jobs in each queue.  
-The metrics will be registered under the name `horizon_current_workload.<queue_name>`.
+The `CurrentJobsMetric` will register the current number of jobs in each queue.  
+The metrics will be registered under the name `horizon_current_jobs.<queue_name>`.
 
 The default schedule for this is every 10 minutes (`*/10 * * * *`), to configure this,
-add `MeterName::CurrentWorkload->value` under a `horizon` key in your `telemetry.php` config file.
+add `MeterName::CurrentJobs->value` under a `horizon` key in your `telemetry.php` config file.
 
 ### Event Listeners
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This package adds support for creating various matrices on your queues with the 
 
 This package requires that the scheduler is running, as it is adding new scheduled commands.
 
-
 ## Installation
 
 You can install the package via composer:
@@ -20,10 +19,41 @@ composer require worksome/horizon-telemetry
 
 ## Usage
 
-### CurrentWorkloadMetric
-The `CurrentWorkloadMetric` will register what the workload is in the different queues.  
-This means you will have a histogram over the number of jobs in each queue.  
+### Metrics
+
+#### [`CurrentMasterSupervisorsMetric`](src/Metrics/CurrentMasterSupervisorsMetric.php)
+
+The `CurrentMasterSupervisorsMetric` will register the current number of master supervisors.  
+The metric will be registered under the name `horizon_current_master_supervisors`.
+
+The default schedule for this is every 10 minutes (`*/10 * * * *`), to configure this,
+add `MeterName::CurrentMasterSupervisors->value` under a `horizon` key in your `telemetry.php` config file.
+
+#### [`CurrentProcessesMetric`](src/Metrics/CurrentProcessesMetric.php)
+
+The `CurrentProcessesMetric` will register the current number of processes in each queue.  
+The metrics will be registered under the name `horizon_current_processes.<queue_name>`.
+
+The default schedule for this is every 10 minutes (`*/10 * * * *`), to configure this,
+add `MeterName::CurrentProcesses->value` under a `horizon` key in your `telemetry.php` config file.
+
+#### [`CurrentWorkloadMetric`](src/Metrics/CurrentWorkloadMetric.php)
+
+The `CurrentWorkloadMetric` will register the current number of jobs in each queue.  
 The metrics will be registered under the name `horizon_current_workload.<queue_name>`.
+
+The default schedule for this is every 10 minutes (`*/10 * * * *`), to configure this,
+add `MeterName::CurrentWorkload->value` under a `horizon` key in your `telemetry.php` config file.
+
+### Event Listeners
+
+#### [`FailedJobsListener`](src/Listeners/FailedJobsListener.php)
+
+The `FailedJobsListener` listener will create an observable counter that will increment each time a job fails.
+This metric will be registered under the name `horizon_failed_jobs`.
+
+The default schedule for this is `true`, to disable this event listener,
+add `MeterName::FailedJobs->value => false` under a `horizon` key in your `telemetry.php` config file.
 
 ## Testing
 

--- a/config/telemetry.php
+++ b/config/telemetry.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Worksome\HorizonTelemetry\Enums\MeterName;
+
+return [
+    'horizon' => [
+        /**
+         * The crontab schedule for the number of current master supervisors.
+         *
+         * This can be either a crontab string, or `false` to disable the check.
+         *
+         * The default is 10 minutes, this can be any configured crontab, or set to `false` to disable this.
+         */
+        MeterName::CurrentMasterSupervisors->value => '*/10 * * * *',
+
+        /**
+         * The crontab schedule for the number of current processes in each queue
+         *
+         * This can be either a crontab string, or `false` to disable the check.
+         *
+         * The default is 10 minutes, this can be any configured crontab, or set to `false` to disable this.
+         */
+        MeterName::CurrentProcesses->value => '*/10 * * * *',
+
+        /**
+         * The crontab schedule for the number of current jobs in each queue.
+         *
+         * This can be either a crontab string, or `false` to disable the check.
+         *
+         * The default is 10 minutes, this can be any configured crontab, or set to `false` to disable this.
+         */
+        MeterName::CurrentWorkload->value => '*/10 * * * *',
+
+        /**
+         * Whether the failed job metric listener is enabled.
+         *
+         * The default is `true`, set to `false` to disable this.
+         */
+        MeterName::FailedJobs->value => true,
+    ],
+];

--- a/config/telemetry.php
+++ b/config/telemetry.php
@@ -7,7 +7,7 @@ use Worksome\HorizonTelemetry\Enums\MeterName;
 return [
     'horizon' => [
         /**
-         * The crontab schedule for the number of current master supervisors.
+         * The crontab schedule for the current number of master supervisors.
          *
          * This can be either a crontab string, or `false` to disable the check.
          *
@@ -16,7 +16,7 @@ return [
         MeterName::CurrentMasterSupervisors->value => '*/10 * * * *',
 
         /**
-         * The crontab schedule for the number of current processes in each queue
+         * The crontab schedule for the current number of processes in each queue
          *
          * This can be either a crontab string, or `false` to disable the check.
          *
@@ -25,13 +25,13 @@ return [
         MeterName::CurrentProcesses->value => '*/10 * * * *',
 
         /**
-         * The crontab schedule for the number of current jobs in each queue.
+         * The crontab schedule for the current number of jobs in each queue.
          *
          * This can be either a crontab string, or `false` to disable the check.
          *
          * The default is 10 minutes, this can be any configured crontab, or set to `false` to disable this.
          */
-        MeterName::CurrentWorkload->value => '*/10 * * * *',
+        MeterName::CurrentJobs->value => '*/10 * * * *',
 
         /**
          * Whether the failed job metric listener is enabled.

--- a/src/Enums/MeterName.php
+++ b/src/Enums/MeterName.php
@@ -8,7 +8,7 @@ enum MeterName: string
 {
     case CurrentMasterSupervisors = 'horizon_current_master_supervisors';
     case CurrentProcesses = 'horizon_current_processes';
-    case CurrentWorkload = 'horizon_current_workload';
+    case CurrentJobs = 'horizon_current_jobs';
     case FailedJobs = 'horizon_failed_jobs';
 
     public function with(string ...$names): string

--- a/src/Enums/MeterName.php
+++ b/src/Enums/MeterName.php
@@ -2,11 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Worksome\HorizonTelemetry;
+namespace Worksome\HorizonTelemetry\Enums;
 
 enum MeterName: string
 {
+    case CurrentMasterSupervisors = 'horizon_current_master_supervisors';
+    case CurrentProcesses = 'horizon_current_processes';
     case CurrentWorkload = 'horizon_current_workload';
+    case FailedJobs = 'horizon_failed_jobs';
 
     public function with(string ...$names): string
     {

--- a/src/Enums/MeterUnit.php
+++ b/src/Enums/MeterUnit.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\HorizonTelemetry\Enums;
+
+enum MeterUnit: string
+{
+    case MasterSupervisors = 'master supervisors';
+    case Processes = 'processes';
+    case Jobs = 'jobs';
+}

--- a/src/HorizonTelemetryServiceProvider.php
+++ b/src/HorizonTelemetryServiceProvider.php
@@ -13,7 +13,7 @@ use Worksome\HorizonTelemetry\Enums\MeterName;
 use Worksome\HorizonTelemetry\Listeners\FailedJobsListener;
 use Worksome\HorizonTelemetry\Metrics\CurrentMasterSupervisorsMetric;
 use Worksome\HorizonTelemetry\Metrics\CurrentProcessesMetric;
-use Worksome\HorizonTelemetry\Metrics\CurrentWorkloadMetric;
+use Worksome\HorizonTelemetry\Metrics\CurrentJobsMetric;
 
 class HorizonTelemetryServiceProvider extends ServiceProvider
 {
@@ -47,10 +47,10 @@ class HorizonTelemetryServiceProvider extends ServiceProvider
                     ->name(MeterName::CurrentProcesses->value);
             }
 
-            if ($currentWorkloadSchedule = $config->get(self::CONFIG_PREFIX . MeterName::CurrentWorkload->value)) {
-                $schedule->call(CurrentWorkloadMetric::class)
-                    ->cron($currentWorkloadSchedule)
-                    ->name(MeterName::CurrentWorkload->value);
+            if ($currentJobsSchedule = $config->get(self::CONFIG_PREFIX . MeterName::CurrentJobs->value)) {
+                $schedule->call(CurrentJobsMetric::class)
+                    ->cron($currentJobsSchedule)
+                    ->name(MeterName::CurrentJobs->value);
             }
         });
     }

--- a/src/HorizonTelemetryServiceProvider.php
+++ b/src/HorizonTelemetryServiceProvider.php
@@ -5,20 +5,58 @@ declare(strict_types=1);
 namespace Worksome\HorizonTelemetry;
 
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Support\ServiceProvider;
+use Worksome\HorizonTelemetry\Enums\MeterName;
+use Worksome\HorizonTelemetry\Listeners\FailedJobsListener;
+use Worksome\HorizonTelemetry\Metrics\CurrentMasterSupervisorsMetric;
+use Worksome\HorizonTelemetry\Metrics\CurrentProcessesMetric;
 use Worksome\HorizonTelemetry\Metrics\CurrentWorkloadMetric;
 
 class HorizonTelemetryServiceProvider extends ServiceProvider
 {
-    public function boot(): void
+    private const CONFIG_PATH = __DIR__ . '/../config/telemetry.php';
+
+    private const CONFIG_PREFIX = 'telemetry.horizon.';
+
+    public function boot(Dispatcher $dispatcher, Repository $config): void
     {
+        if ($config->get(self::CONFIG_PREFIX . MeterName::FailedJobs->value)) {
+            $dispatcher->listen(JobFailed::class, FailedJobsListener::class);
+        }
+
         $this->app->booted(function () {
             /** @var Schedule $schedule */
             $schedule = $this->app->make(Schedule::class);
+            /** @var Repository $schedule */
+            $config = $this->app->make(Repository::class);
 
-            $schedule->call(CurrentWorkloadMetric::class)
-                ->everyTenMinutes()
-                ->name('CurrentWorkloadMetric');
+            if ($currentMasterSupervisorsSchedule = $config->get(
+                self::CONFIG_PREFIX . MeterName::CurrentMasterSupervisors->value
+            )) {
+                $schedule->call(CurrentMasterSupervisorsMetric::class)
+                    ->cron($currentMasterSupervisorsSchedule)
+                    ->name(MeterName::CurrentMasterSupervisors->value);
+            }
+
+            if ($currentProcessesSchedule = $config->get(self::CONFIG_PREFIX . MeterName::CurrentProcesses->value)) {
+                $schedule->call(CurrentProcessesMetric::class)
+                    ->cron($currentProcessesSchedule)
+                    ->name(MeterName::CurrentProcesses->value);
+            }
+
+            if ($currentWorkloadSchedule = $config->get(self::CONFIG_PREFIX . MeterName::CurrentWorkload->value)) {
+                $schedule->call(CurrentWorkloadMetric::class)
+                    ->cron($currentWorkloadSchedule)
+                    ->name(MeterName::CurrentWorkload->value);
+            }
         });
+    }
+
+    public function register(): void
+    {
+        $this->mergeConfigFrom(self::CONFIG_PATH, 'telemetry');
     }
 }

--- a/src/Listeners/FailedJobsListener.php
+++ b/src/Listeners/FailedJobsListener.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\HorizonTelemetry\Listeners;
+
+use OpenTelemetry\API\Metrics\ObserverInterface;
+use Worksome\HorizonTelemetry\Enums\MeterName;
+use Worksome\HorizonTelemetry\Enums\MeterUnit;
+use Worksome\HorizonTelemetry\MeterProvider;
+
+readonly class FailedJobsListener
+{
+    public function __construct(
+        private MeterProvider $meterProvider,
+    ) {
+    }
+
+    public function __invoke(): void
+    {
+        $meter = $this->meterProvider->getMeter(MeterName::FailedJobs);
+
+        $meter->createObservableCounter(
+            MeterName::FailedJobs->value,
+            MeterUnit::Jobs->value,
+            'The number of failed jobs.',
+            fn (ObserverInterface $observer) => $observer->observe(1)
+        );
+    }
+}

--- a/src/Listeners/FailedJobsListener.php
+++ b/src/Listeners/FailedJobsListener.php
@@ -20,7 +20,7 @@ readonly class FailedJobsListener
     {
         $meter = $this->meterProvider->getMeter(MeterName::FailedJobs);
 
-        $meter->createObservableCounter(
+        $meter->createObservableUpDownCounter(
             MeterName::FailedJobs->value,
             MeterUnit::Jobs->value,
             'The number of failed jobs.',

--- a/src/MeterProvider.php
+++ b/src/MeterProvider.php
@@ -6,6 +6,7 @@ namespace Worksome\HorizonTelemetry;
 
 use OpenTelemetry\API\Metrics\MeterInterface;
 use OpenTelemetry\API\Metrics\MeterProviderInterface;
+use Worksome\HorizonTelemetry\Enums\MeterName;
 
 readonly class MeterProvider
 {

--- a/src/Metrics/CurrentJobsMetric.php
+++ b/src/Metrics/CurrentJobsMetric.php
@@ -11,7 +11,7 @@ use Worksome\HorizonTelemetry\Enums\MeterName;
 use Worksome\HorizonTelemetry\Enums\MeterUnit;
 use Worksome\HorizonTelemetry\MeterProvider;
 
-readonly class CurrentWorkloadMetric
+readonly class CurrentJobsMetric
 {
     public function __construct(
         private MeterProvider $meterProvider,
@@ -21,14 +21,14 @@ readonly class CurrentWorkloadMetric
 
     public function __invoke(): void
     {
-        $meter = $this->meterProvider->getMeter(MeterName::CurrentWorkload);
+        $meter = $this->meterProvider->getMeter(MeterName::CurrentJobs);
 
         Collection::make($this->workloadRepository->get())
             ->each(function (array $workload) use ($meter) {
                 /** @var array{name: string, length: integer, wait: double, processes: int, split_queues: array} $workload */
 
                 $meter->createObservableGauge(
-                    MeterName::CurrentWorkload->with($workload['name']),
+                    MeterName::CurrentJobs->with($workload['name']),
                     MeterUnit::Jobs->value,
                     'The total number of jobs per queue.',
                     fn (ObserverInterface $observer) => $observer->observe($workload['length'])

--- a/src/Metrics/CurrentMasterSupervisorsMetric.php
+++ b/src/Metrics/CurrentMasterSupervisorsMetric.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\HorizonTelemetry\Metrics;
+
+use Illuminate\Support\Collection;
+use Laravel\Horizon\Contracts\MasterSupervisorRepository;
+use OpenTelemetry\API\Metrics\ObserverInterface;
+use Worksome\HorizonTelemetry\Enums\MeterName;
+use Worksome\HorizonTelemetry\Enums\MeterUnit;
+use Worksome\HorizonTelemetry\MeterProvider;
+
+readonly class CurrentMasterSupervisorsMetric
+{
+    public function __construct(
+        private MeterProvider $meterProvider,
+        private MasterSupervisorRepository $masterSupervisorRepository,
+    ) {
+    }
+
+    public function __invoke(): void
+    {
+        $meter = $this->meterProvider->getMeter(MeterName::CurrentMasterSupervisors);
+
+        $masterSupervisors = Collection::make($this->masterSupervisorRepository->all());
+
+        $meter->createObservableGauge(
+            MeterName::CurrentMasterSupervisors->value,
+            MeterUnit::MasterSupervisors->value,
+            'The total number of master supervisors.',
+            fn (ObserverInterface $observer) => $observer->observe($masterSupervisors->count())
+        );
+    }
+}

--- a/src/Metrics/CurrentProcessesMetric.php
+++ b/src/Metrics/CurrentProcessesMetric.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\HorizonTelemetry\Metrics;
+
+use Illuminate\Support\Collection;
+use Laravel\Horizon\Contracts\WorkloadRepository;
+use OpenTelemetry\API\Metrics\ObserverInterface;
+use Worksome\HorizonTelemetry\Enums\MeterName;
+use Worksome\HorizonTelemetry\Enums\MeterUnit;
+use Worksome\HorizonTelemetry\MeterProvider;
+
+readonly class CurrentProcessesMetric
+{
+    public function __construct(
+        private MeterProvider $meterProvider,
+        private WorkloadRepository $workloadRepository,
+    ) {
+    }
+
+    public function __invoke(): void
+    {
+        $meter = $this->meterProvider->getMeter(MeterName::CurrentProcesses);
+
+        Collection::make($this->workloadRepository->get())
+            ->each(
+                function (array $workload) use ($meter) {
+                    /** @var array{name: string, length: integer, wait: double, processes: int, split_queues: array} $workload */
+
+                    $meter->createObservableGauge(
+                        MeterName::CurrentProcesses->with($workload['name']),
+                        MeterUnit::Processes->value,
+                        'The total number of processes per queue.',
+                        fn (ObserverInterface $observer) => $observer->observe($workload['processes'])
+                    );
+                }
+            );
+    }
+}

--- a/src/Metrics/CurrentWorkloadMetric.php
+++ b/src/Metrics/CurrentWorkloadMetric.php
@@ -6,7 +6,9 @@ namespace Worksome\HorizonTelemetry\Metrics;
 
 use Illuminate\Support\Collection;
 use Laravel\Horizon\Contracts\WorkloadRepository;
-use Worksome\HorizonTelemetry\MeterName;
+use OpenTelemetry\API\Metrics\ObserverInterface;
+use Worksome\HorizonTelemetry\Enums\MeterName;
+use Worksome\HorizonTelemetry\Enums\MeterUnit;
 use Worksome\HorizonTelemetry\MeterProvider;
 
 readonly class CurrentWorkloadMetric
@@ -25,17 +27,11 @@ readonly class CurrentWorkloadMetric
             ->each(function (array $workload) use ($meter) {
                 /** @var array{name: string, length: integer, wait: double, processes: int, split_queues: array} $workload */
 
-                $counter = $meter->createHistogram(
-                    MeterName::CurrentWorkload->with($workload['name'])
-                );
-
-                $counter->record(
-                    $workload['length'],
-                    [
-                        'length' => $workload['length'],
-                        'wait' => $workload['wait'],
-                        'processes' => $workload['processes'],
-                    ],
+                $meter->createObservableGauge(
+                    MeterName::CurrentWorkload->with($workload['name']),
+                    MeterUnit::Jobs->value,
+                    'The total number of jobs per queue.',
+                    fn (ObserverInterface $observer) => $observer->observe($workload['length'])
                 );
             });
     }


### PR DESCRIPTION
This adds 2 new metrics (`horizon_current_master_supervisors` and `horizon_current_processes`), as well as a new event listener for `horizon_failed_jobs`.

These metrics are now all configurable via the `config/telemetry.php` file (under a `horizon` key). 👍🏻